### PR TITLE
Fix casing issue in destructuring assignment

### DIFF
--- a/server/routes/river-by-riverid-or-wiskiname.js
+++ b/server/routes/river-by-riverid-or-wiskiname.js
@@ -7,8 +7,8 @@ module.exports = {
   path: '/river-by-riverid-or-wiskiname/{riverId}/{riverName}',
   handler: async request => {
     try {
-      const { riverID, riverName } = request.params
-      return services.getRiverByIdOrWiskiName(riverID, riverName)
+      const { riverId, riverName } = request.params
+      return services.getRiverByIdOrWiskiName(riverId, riverName)
     } catch (err) {
       return boom.badRequest('Failed to get stations by river_id or wiski_name', err)
     }

--- a/test/routes/happy-routes.js
+++ b/test/routes/happy-routes.js
@@ -444,16 +444,31 @@ lab.experiment('Happy Route tests', () => {
     Code.expect(response.statusCode).to.equal(200)
   })
 
-  lab.test('GET / route works for /river-by-riverid-or-wiskiname/{riverId}/{riverName}', async () => {
+  lab.experiment('GET / route works for /river-by-riverid-or-wiskiname/{riverId}/{riverName}', () => {
     const options = {
       method: 'GET',
       url: '/river-by-riverid-or-wiskiname/river-tyne/River Tyne'
     }
 
-    sandbox.stub(services, 'getRiverByIdOrWiskiName').returns({ rows: [] })
+    lab.test('Request is successful', async () => {
+      sandbox.stub(services, 'getRiverByIdOrWiskiName').returns({ rows: [] })
 
-    const response = await server.inject(options)
-    Code.expect(response.statusCode).to.equal(200)
+      const response = await server.inject(options)
+      Code.expect(response.statusCode).to.equal(200)
+    })
+
+    lab.test('Correct parameters are passed to service', async () => {
+      const mock = sandbox.mock(services)
+
+      mock.expects('getRiverByIdOrWiskiName')
+        .once()
+        .withExactArgs('river-tyne', 'River Tyne')
+        .returns({ rows: [] })
+
+      await server.inject(options)
+
+      mock.verify()
+    })
   })
 
   lab.test('GET / route works for /rainfall-station-telemetry/{stationId}', async () => {


### PR DESCRIPTION
This bug means that, prior to this change, searches were searches on river name only (since the river id value was undefined) which was fine when river names are unique. I stumbled across the problem when searching for rivers where the name isn't unique (e.g. Ouse/Derwent/etc). In this case the name is passed as, for example, "Ouse (Yorkshire)" which returns 0 results.

Note: River names are not unique in the DB and a search for stations by name "Ouse" will return stations for all river Ouses 

`select * from u_flood.stations_list_mview where river_id = ($1) OR wiski_river_name = ($2) ORDER BY view_rank, river_id, rank, agency_name;`

I think it raises questions about testing which we can talk about.