### PR TITLE
Fix: improve search precision

### DIFF
--- a/server/services/index.js
+++ b/server/services/index.js
@@ -1,5 +1,10 @@
 const db = require('./db')
 
+function escapeRegExp (string) {
+  // source: https://stackoverflow.com/questions/3446170/escape-string-for-use-in-javascript-regex
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // $& means the whole matched string
+}
+
 module.exports = {
   async getFloods () {
     const result = await db.query('getFloods')
@@ -52,8 +57,8 @@ module.exports = {
     return rows
   },
 
-  async getRiversByName (location) {
-    const { rows } = await db.query('getRiversByName', [location])
+  async getRiversByName (searchTerm) {
+    const { rows } = await db.query('getRiversByName', [`\\m${escapeRegExp(searchTerm)}\\M`])
     return rows
   },
 

--- a/server/services/queries.json
+++ b/server/services/queries.json
@@ -24,5 +24,5 @@
   "getStationsByRadius" : "select * from u_flood.stations_list_mview where ST_DWithin(centroid::geography, ST_MakePoint($1, $2)::geography, $3) ORDER BY view_rank, river_id, \"rank\", agency_name;",
   "getRainfallStationTelemetry" : "select DISTINCT a.period,b.value,b.value_timestamp from sls_telemetry_value_parent a inner join sls_telemetry_value b on a.telemetry_value_parent_id = b.telemetry_value_parent_id inner join sls_telemetry_station c on c.station_reference = a.station where a.station = $1 and b.value_timestamp > now() - interval '5 Days' order by b.value_timestamp desc;",
   "getRainfallStation" : "select a.*, b.lat, b.lon from rainfall_stations_mview a inner join stations_list_mview b on a.station_reference = b.telemetry_id where a.station_reference = $1",
-  "getRiversByName" : "SELECT * FROM river WHERE lower($1) NOT SIMILAR TO 'river|brook|stream|water' AND (lower(name) LIKE concat('%', lower($1), '%') OR lower(qualified_name) = lower($1)) ORDER BY qualified_name"
+  "getRiversByName" : "SELECT * FROM river WHERE $1 !~* '^(river|brook|stream|water)$' AND (name ~* $1 OR lower(qualified_name) = lower($1)) ORDER BY qualified_name"
 }


### PR DESCRIPTION
* Made searching specific to whole words so short search terms (such as
  'e' and 'ee' will not return lots of values
* Added escaping of regex characters as a belt and braces measure after
  a search term of '(' was found to break the db query.

Note: the current query would not benefit from indexing due to the use of
lower() and regexes. Query times locally were not greatly improved by
adding a btree index even for equality searches without lower(). This is
probably because there are only 1k records. May need to revisit this
decision after performance testing.
