### PR TITLE
Fix: no results returned for search term containing parentheses

### DIFF
--- a/server/services/index.js
+++ b/server/services/index.js
@@ -1,8 +1,10 @@
 const db = require('./db')
 
-function escapeRegExp (string) {
-  // source: https://stackoverflow.com/questions/3446170/escape-string-for-use-in-javascript-regex
-  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // $& means the whole matched string
+function regexClean (string) {
+  // remove brackets which were causing issues when mismatched pairings were present
+  // this does not affect the results returned as brackets are treated as word boundary characters
+  // and therefore the \m and \M in the query will match the same with or without them
+  return string.replace(/[{}[\]()]*/g, '')
 }
 
 module.exports = {
@@ -58,7 +60,7 @@ module.exports = {
   },
 
   async getRiversByName (searchTerm) {
-    const { rows } = await db.query('getRiversByName', [escapeRegExp(searchTerm)])
+    const { rows } = await db.query('getRiversByName', [searchTerm, regexClean(searchTerm)])
     return rows
   },
 

--- a/server/services/queries.json
+++ b/server/services/queries.json
@@ -24,5 +24,5 @@
   "getStationsByRadius" : "select * from u_flood.stations_list_mview where ST_DWithin(centroid::geography, ST_MakePoint($1, $2)::geography, $3) ORDER BY view_rank, river_id, \"rank\", agency_name;",
   "getRainfallStationTelemetry" : "select DISTINCT a.period,b.value,b.value_timestamp from sls_telemetry_value_parent a inner join sls_telemetry_value b on a.telemetry_value_parent_id = b.telemetry_value_parent_id inner join sls_telemetry_station c on c.station_reference = a.station where a.station = $1 and b.value_timestamp > now() - interval '5 Days' order by b.value_timestamp desc;",
   "getRainfallStation" : "select a.*, b.lat, b.lon from rainfall_stations_mview a inner join stations_list_mview b on a.station_reference = b.telemetry_id where a.station_reference = $1",
-  "getRiversByName" : "SELECT * FROM river WHERE $1 !~* '^(river|brook|stream|water)$' AND (name ~* concat('\\m', $1, '\\M')  OR lower(qualified_name) = lower($1)) ORDER BY qualified_name"
+  "getRiversByName" : "SELECT * FROM river WHERE $1 !~* '^(river|brook|stream|water)$' AND (name ~* concat('\\m', $2::text, '\\M')  OR lower(qualified_name) = lower($1)) ORDER BY qualified_name"
 }


### PR DESCRIPTION
Search containing parentheses was failing to return any results when there was a matching qualified river name (e.g. _River Derwent (Cumbria)_).

Also, mismatched parentheses were causing a postgres exception in the match check against the unqualified river name. Solution was to remove all brackets from the search term as passed to the regex.

See notes in code for background