### PR TITLE
FSR 1043 - fix unhandled 500 errors on /rainfall-station endpoints

### DIFF
--- a/server/routes/rainfall-station.js
+++ b/server/routes/rainfall-station.js
@@ -7,7 +7,11 @@ module.exports = {
   path: '/rainfall-station/{stationId}',
   handler: async request => {
     try {
-      return await floodsService.getRainfallStation(request.params.stationId)
+      const rainfallStation = await floodsService.getRainfallStation(request.params.stationId)
+      if (!rainfallStation) {
+        return Boom.notFound('No rainfall station data found')
+      }
+      return rainfallStation
     } catch (err) {
       return Boom.badRequest('Failed to get rainfall by station data', err)
     }

--- a/server/services/index.js
+++ b/server/services/index.js
@@ -85,8 +85,8 @@ module.exports = {
   },
 
   async getRainfallStation (stationId) {
-    const { rows } = await db.query('getRainfallStation', [stationId])
-    return rows
+    const { rows: [rainfallStation] } = await db.query('getRainfallStation', [stationId])
+    return rainfallStation
   },
 
   async getRiverStationByStationId (stationId, direction) {

--- a/test/routes/404.js
+++ b/test/routes/404.js
@@ -64,4 +64,18 @@ lab.experiment('404 Route tests', () => {
     Code.expect(response.statusCode).to.equal(404)
     Code.expect(response.payload).to.include('Station 7333 (u)')
   })
+
+  lab.test('4 - null return works for /rainfall-station/{stationId}', async () => {
+    const options = {
+      method: 'GET',
+      url: '/rainfall-station/123456'
+
+    }
+
+    sandbox.stub(services, 'getRainfallStation')
+
+    const response = await server.inject(options)
+    Code.expect(response.statusCode).to.equal(404)
+    Code.expect(response.payload).to.include('{"statusCode":404,"error":"Not Found","message":"No rainfall station data found"}')
+  })
 })

--- a/test/services/index.js
+++ b/test/services/index.js
@@ -933,14 +933,20 @@ lab.experiment('Services tests', () => {
     lab.test('should return empty rows array', async () => {
       sinon.stub(db, 'query').returns({ rows: [] })
       const result = await services.getRainfallStation()
-      await Code.expect(result).to.be.an.array()
-      await Code.expect(result).to.equal([])
+      await Code.expect(result).to.be.undefined()
     })
     lab.test('should return populated rows array', async () => {
       sinon.stub(db, 'query').returns({ rows: [{ station_reference: 'E24195', region: 'Anglian', station_name: 'LAVENHAM', ngr: 'TL9237348710', period: '15 min', units: 'mm' }] })
       const result = await services.getRainfallStation()
-      await Code.expect(result).to.be.an.array()
-      await Code.expect(result).to.equal([{ station_reference: 'E24195', region: 'Anglian', station_name: 'LAVENHAM', ngr: 'TL9237348710', period: '15 min', units: 'mm' }])
+      await Code.expect(result).to.be.an.object()
+      await Code.expect(result).to.equal({
+        station_reference: 'E24195',
+        region: 'Anglian',
+        station_name: 'LAVENHAM',
+        ngr: 'TL9237348710',
+        period: '15 min',
+        units: 'mm'
+      })
     })
     lab.test('should pass query and rainfall gauge id', async () => {
       const mock = sinon.mock(db)


### PR DESCRIPTION
**NOTE: This PR should be tested/released in tandem with https://github.com/DEFRA/flood-app/pull/550**

# What
- Update `getRainfallStation()` to return object or undefined rather than an array
- Update consumers of `getRainfallStation()` to expect object rather than an array
- Update routes depending on `getRainfallStation()` to respond 404 if no object is returned from the function
