### PR TITLE
FSR-1052 | Errbit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "7.5.0",
       "license": "ISC",
       "dependencies": {
+        "@airbrake/node": "^2.1.8",
         "@hapi/boom": "10.0.1",
         "@hapi/code": "^9.0.3",
         "@hapi/hapi": "^21.3.2",
@@ -19,6 +20,7 @@
         "hapi-pino": "^12.1.0",
         "pg": "8.11.2",
         "pino": "^8.16.0",
+        "pino-abstract-transport": "^1.1.0",
         "pino-pretty": "^10.2.3",
         "proxy-agent": "6.3.0",
         "proxyquire": "^2.1.3",
@@ -36,6 +38,33 @@
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@airbrake/browser": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@airbrake/browser/-/browser-2.1.8.tgz",
+      "integrity": "sha512-3xzpkQUq48R+hVbGlxUFLnv8dZg7M9OhBceX473ZrX4osxgfuKRqB+ecNawevKOftBrsjK2gNBayCXTbE+yFzQ==",
+      "dependencies": {
+        "@types/promise-polyfill": "^6.0.3",
+        "@types/request": "2.48.8",
+        "cross-fetch": "^3.1.5",
+        "error-stack-parser": "^2.0.4",
+        "promise-polyfill": "^8.1.3",
+        "tdigest": "^0.1.1"
+      }
+    },
+    "node_modules/@airbrake/node": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@airbrake/node/-/node-2.1.8.tgz",
+      "integrity": "sha512-JuEFJk9hW+5YL4kSS+E6KuiBS9YleWnzo+Fu1j9E3VXOC8bGr+wxMGfhQGFuDBHmpco3g4wAY4t+IHZMtaN0rQ==",
+      "dependencies": {
+        "@airbrake/browser": "^2.1.8",
+        "cross-fetch": "^3.1.5",
+        "error-stack-parser": "^2.0.4",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1224,10 +1253,44 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
     },
+    "node_modules/@types/caseless": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
+    },
+    "node_modules/@types/node": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
+      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/promise-polyfill": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@types/promise-polyfill/-/promise-polyfill-6.0.6.tgz",
+      "integrity": "sha512-nKg0HIgdKRKfi5S3IlrpiNWqxiJOqYOV70jAtalqhvb5zJt5IoQMgy1QS3y5wsbUQPOCZHQxaPg+btBUVbA+hA=="
+    },
+    "node_modules/@types/request": {
+      "version": "2.48.8",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.8.tgz",
+      "integrity": "sha512-whjk1EDJPcAR2kYHRbFl/lKeeKYTi05A15K9bnLInCVroNDCtXce57xKdI0/rQaA3K+6q0eFyUBPmqfSndUZdQ==",
+      "dependencies": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -1446,6 +1509,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -1515,6 +1583,11 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
     "node_modules/blipp": {
       "version": "4.0.2",
@@ -1808,6 +1881,17 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1817,6 +1901,14 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -1908,6 +2000,14 @@
         "node": ">= 14"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/diff": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
@@ -1968,6 +2068,14 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "dependencies": {
+        "stackframe": "^1.3.4"
       }
     },
     "node_modules/es-abstract": {
@@ -2976,6 +3084,19 @@
         "is-callable": "^1.1.3"
       }
     },
+    "node_modules/form-data": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -3915,6 +4036,17 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3991,6 +4123,25 @@
       "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
       "dependencies": {
         "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-releases": {
@@ -4526,6 +4677,11 @@
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
       "integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg=="
     },
+    "node_modules/promise-polyfill": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
+      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg=="
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -5035,6 +5191,11 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
+    },
     "node_modules/standard": {
       "version": "17.1.0",
       "resolved": "https://registry.npmjs.org/standard/-/standard-17.1.0.tgz",
@@ -5222,6 +5383,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "dependencies": {
+        "bintrees": "1.0.2"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -5253,6 +5422,11 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
@@ -5398,6 +5572,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -5486,6 +5665,20 @@
       "optional": true,
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -5616,6 +5809,30 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA=="
+    },
+    "@airbrake/browser": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@airbrake/browser/-/browser-2.1.8.tgz",
+      "integrity": "sha512-3xzpkQUq48R+hVbGlxUFLnv8dZg7M9OhBceX473ZrX4osxgfuKRqB+ecNawevKOftBrsjK2gNBayCXTbE+yFzQ==",
+      "requires": {
+        "@types/promise-polyfill": "^6.0.3",
+        "@types/request": "2.48.8",
+        "cross-fetch": "^3.1.5",
+        "error-stack-parser": "^2.0.4",
+        "promise-polyfill": "^8.1.3",
+        "tdigest": "^0.1.1"
+      }
+    },
+    "@airbrake/node": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@airbrake/node/-/node-2.1.8.tgz",
+      "integrity": "sha512-JuEFJk9hW+5YL4kSS+E6KuiBS9YleWnzo+Fu1j9E3VXOC8bGr+wxMGfhQGFuDBHmpco3g4wAY4t+IHZMtaN0rQ==",
+      "requires": {
+        "@airbrake/browser": "^2.1.8",
+        "cross-fetch": "^3.1.5",
+        "error-stack-parser": "^2.0.4",
+        "tdigest": "^0.1.1"
+      }
     },
     "@ampproject/remapping": {
       "version": "2.2.1",
@@ -6676,10 +6893,44 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
     },
+    "@types/caseless": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
+    },
+    "@types/node": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
+      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "@types/promise-polyfill": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@types/promise-polyfill/-/promise-polyfill-6.0.6.tgz",
+      "integrity": "sha512-nKg0HIgdKRKfi5S3IlrpiNWqxiJOqYOV70jAtalqhvb5zJt5IoQMgy1QS3y5wsbUQPOCZHQxaPg+btBUVbA+hA=="
+    },
+    "@types/request": {
+      "version": "2.48.8",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.8.tgz",
+      "integrity": "sha512-whjk1EDJPcAR2kYHRbFl/lKeeKYTi05A15K9bnLInCVroNDCtXce57xKdI0/rQaA3K+6q0eFyUBPmqfSndUZdQ==",
+      "requires": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      }
+    },
+    "@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="
     },
     "abort-controller": {
       "version": "3.0.0",
@@ -6835,6 +7086,11 @@
         "tslib": "^2.0.1"
       }
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -6875,6 +7131,11 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
       "integrity": "sha512-QHX8HLlncOLpy54mh+k/sWIFd0ThmRqwe9ZjELybGZK+tZ8rUb9VO0saKJUROTbE+KhzDUT7xziGpGrW8Kmd+g=="
+    },
+    "bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
     "blipp": {
       "version": "4.0.2",
@@ -7087,6 +7348,14 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -7096,6 +7365,14 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+    },
+    "cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "requires": {
+        "node-fetch": "^2.6.12"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -7158,6 +7435,11 @@
         "esprima": "^4.0.1"
       }
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
     "diff": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
@@ -7207,6 +7489,14 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "requires": {
+        "stackframe": "^1.3.4"
       }
     },
     "es-abstract": {
@@ -7911,6 +8201,16 @@
         "is-callable": "^1.1.3"
       }
     },
+    "form-data": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -8588,6 +8888,14 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
     "minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -8654,6 +8962,14 @@
             "type-detect": "4.0.8"
           }
         }
+      }
+    },
+    "node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
       }
     },
     "node-releases": {
@@ -9056,6 +9372,11 @@
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
       "integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg=="
     },
+    "promise-polyfill": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
+      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg=="
+    },
     "prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -9400,6 +9721,11 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
       "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ=="
     },
+    "stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
+    },
     "standard": {
       "version": "17.1.0",
       "resolved": "https://registry.npmjs.org/standard/-/standard-17.1.0.tgz",
@@ -9511,6 +9837,14 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
+    "tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "requires": {
+        "bintrees": "1.0.2"
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -9536,6 +9870,11 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "tsconfig-paths": {
       "version": "3.14.2",
@@ -9641,6 +9980,11 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -9701,6 +10045,20 @@
       "optional": true,
       "requires": {
         "defaults": "^1.0.3"
+      }
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@airbrake/node": "^2.1.8",
     "@hapi/boom": "10.0.1",
     "@hapi/code": "^9.0.3",
     "@hapi/hapi": "^21.3.2",
@@ -24,6 +25,7 @@
     "hapi-pino": "^12.1.0",
     "pg": "8.11.2",
     "pino": "^8.16.0",
+    "pino-abstract-transport": "^1.1.0",
     "pino-pretty": "^10.2.3",
     "proxy-agent": "6.3.0",
     "proxyquire": "^2.1.3",

--- a/server/config.js
+++ b/server/config.js
@@ -12,7 +12,13 @@ const schema = joi.object({
     httpTimeoutMs: joi.number().default(10000)
   }),
   logLevel: joi.string().default('info'),
-  isPM2: joi.boolean().default(false)
+  isPM2: joi.boolean().default(false),
+  errbit: joi.object({
+    enabled: joi.boolean().default(false),
+    host: joi.string().default('https://errbit-prd.aws-int.defra.cloud'),
+    projectId: joi.number().default(1),
+    projectKey: joi.string()
+  })
 })
 
 // Build config
@@ -27,7 +33,13 @@ const config = {
     httpTimeoutMs: process.env.FLOOD_SERVICE_S3_TIMEOUT
   },
   logLevel: process.env.LOG_LEVEL,
-  isPM2: !!process.env.PM2_HOME
+  isPM2: !!process.env.PM2_HOME,
+  errbit: {
+    enabled: process.env.ERRBIT_ENABLED === 'true',
+    host: process.env.ERRBIT_HOST,
+    projectId: process.env.ERRBIT_PROJECT_ID,
+    projectKey: process.env.ERRBIT_PROJECT_KEY
+  }
 }
 
 // Validate config

--- a/server/lib/logging/create-errbit-target.js
+++ b/server/lib/logging/create-errbit-target.js
@@ -1,0 +1,18 @@
+'use strict'
+const config = require('../../config')
+
+module.exports = function createLoggingTarget (level, severity) {
+  return {
+    level,
+    target: require.resolve('./errbit-transport'),
+    options: {
+      severity,
+      projectKey: config.errbit.projectKey,
+      projectId: config.errbit.projectId,
+      enabled: config.errbit.enabled,
+      host: config.errbit.host,
+      environment: config.env,
+      version: config.version
+    }
+  }
+}

--- a/server/lib/logging/errbit-transport.js
+++ b/server/lib/logging/errbit-transport.js
@@ -1,0 +1,17 @@
+'use strict'
+const Errbit = require('./errbit')
+const createAbstractTransport = require('pino-abstract-transport')
+
+module.exports = ({ severity, enabled, host, projectId, projectKey, environment, version }) => {
+  const errbit = new Errbit({ severity, enabled, host, projectId, projectKey, environment, version })
+
+  return createAbstractTransport(async source => {
+    for await (const data of source) {
+      if (data.err) {
+        await errbit.send(data).catch(console.error)
+      }
+    }
+  }, {
+    close: () => errbit.close().catch(console.error)
+  })
+}

--- a/server/lib/logging/errbit.js
+++ b/server/lib/logging/errbit.js
@@ -1,0 +1,51 @@
+'use strict'
+const { Notifier } = require('@airbrake/node')
+
+module.exports = class Errbit {
+  constructor (opts) {
+    this._opts = opts
+    if (this._opts.enabled) {
+      this._airbrake = new Notifier({
+        host: this._opts.host,
+        projectId: this._opts.projectId,
+        projectKey: this._opts.projectKey,
+        environment: this._opts.environment,
+        errorNotifications: true,
+        remoteConfig: false
+      })
+    }
+  }
+
+  _formatNotice (data) {
+    const notification = {
+      error: data.err,
+      context: {
+        environment: this._opts.environment,
+        version: this._opts.version,
+        severity: this._opts.severity
+      },
+      params: {}
+    }
+    if (data.req) {
+      notification.context.httpMethod = data.req.method
+      notification.context.route = data.req.url
+      notification.params.request = data.req
+    }
+    if (data.res) {
+      notification.params.response = data.res
+    }
+    return notification
+  }
+
+  async send (data) {
+    if (this._airbrake) {
+      await this._airbrake.notify(this._formatNotice(data))
+    }
+  }
+
+  async close () {
+    if (this._airbrake) {
+      await this._airbrake.flush(1000)
+    }
+  }
+}

--- a/server/lib/logging/pino.js
+++ b/server/lib/logging/pino.js
@@ -2,6 +2,7 @@
 const pino = require('pino')
 const config = require('../../config')
 const createLoggingTarget = require('./create-logging-target')
+const createErrbitTarget = require('./create-errbit-target')
 
 module.exports = pino({
   level: config.logLevel.toLowerCase(),
@@ -15,6 +16,8 @@ module.exports = pino({
   }
 }, pino.transport({
   targets: [
+    createErrbitTarget('fatal', 'critical'),
+    createErrbitTarget('error', 'error'),
     createLoggingTarget('fatal'),
     createLoggingTarget('error'),
     createLoggingTarget('warn'),

--- a/server/util.js
+++ b/server/util.js
@@ -11,7 +11,7 @@ async function request (method, url, options) {
     payload = response.payload
   } catch (error) {
     if (error?.message?.startsWith('Response Error:')) {
-      error.message += ` on ${method.toUpperCase()} ${redactKeyQueryString(url)}`
+      error.message += ` on ${method.toUpperCase()} ${url.replace(/\?.*$/, '')}`
     }
     throw error
   }
@@ -38,10 +38,6 @@ function postJson (url, options) {
 
 function getJson (url) {
   return get(url, { json: true })
-}
-
-function redactKeyQueryString (urlString) {
-  return urlString.replace(/([?&])key=[^&]*(&|$)/, (_match, a, b) => `${a}key=<redacted>${b}`)
 }
 
 module.exports = {

--- a/test/lib/logging/errbit-transport.js
+++ b/test/lib/logging/errbit-transport.js
@@ -1,0 +1,166 @@
+'use strict'
+const Lab = require('@hapi/lab')
+const { expect } = require('@hapi/code')
+const { experiment, test, beforeEach, afterEach, after } = exports.lab = Lab.script()
+const { stub } = require('sinon')
+const proxyquire = require('proxyquire')
+const { once } = require('node:events')
+
+const stubs = {
+  Errbit: stub(),
+  send: stub(),
+  close: stub(),
+  consoleError: stub(console, 'error')
+}
+
+const errbitTransport = proxyquire('../../../server/lib/logging/errbit-transport', {
+  './errbit': stubs.Errbit
+})
+
+experiment('errbit transport', () => {
+  beforeEach(() => {
+    stubs.Errbit.callsFake(() => ({
+      send: stubs.send,
+      close: stubs.close
+    }))
+  })
+  afterEach(() => {
+    for (const stub of Object.values(stubs)) {
+      stub.reset()
+    }
+  })
+  after(() => {
+    for (const stub of Object.values(stubs)) {
+      if (stub.restore) {
+        stub.restore()
+      }
+    }
+  })
+
+  test('it sends messages containing an err to errbit', async () => {
+    const stream = errbitTransport({
+      severity: 'comical',
+      enabled: false,
+      host: 'some-host',
+      projectId: 'some-project-id',
+      projectKey: 'some-project-key',
+      environment: 'unit-test',
+      version: '0.0.0'
+    })
+    stubs.send.resolves()
+    stubs.close.resolves()
+
+    stream.write(JSON.stringify({
+      err: {
+        name: 'some-name',
+        message: 'some-message',
+        stack: 'some-stack',
+        code: 1234
+      }
+    }))
+    stream.end()
+    await once(stream, 'close')
+
+    expect(stubs.send.callCount).to.equal(1)
+    expect(stubs.send.lastCall.args[0]).to.equal({
+      err: {
+        name: 'some-name',
+        message: 'some-message',
+        stack: 'some-stack',
+        code: 1234
+      }
+    })
+  })
+  test('it handles when sending a message to errbit fails', async () => {
+    const stream = errbitTransport({
+      severity: 'comical',
+      enabled: false,
+      host: 'some-host',
+      projectId: 'some-project-id',
+      projectKey: 'some-project-key',
+      environment: 'unit-test',
+      version: '0.0.0'
+    })
+    stubs.send.rejects(new Error('not sent'))
+    stubs.close.resolves()
+
+    let err
+    stream.on('error', (error) => {
+      err = error
+    })
+    stream.write(JSON.stringify({
+      err: {
+        name: 'some-name',
+        message: 'some-message',
+        stack: 'some-stack',
+        code: 1234
+      }
+    }))
+    stream.end()
+    await once(stream, 'close')
+
+    expect(err).to.equal(undefined)
+    expect(stubs.consoleError.lastCall.args[0]).to.equal(new Error('not sent'))
+  })
+  test('it skips messages not containing an err key', async () => {
+    const stream = errbitTransport({
+      severity: 'comical',
+      enabled: false,
+      host: 'some-host',
+      projectId: 'some-project-id',
+      projectKey: 'some-project-key',
+      environment: 'unit-test',
+      version: '0.0.0'
+    })
+    stubs.send.resolves()
+    stubs.close.resolves()
+
+    stream.write(JSON.stringify({
+      message: 'Hello Worlds'
+    }))
+    stream.end()
+    await once(stream, 'close')
+
+    expect(stubs.send.callCount).to.equal(0)
+  })
+
+  test('it closes errbit on close', async () => {
+    const stream = errbitTransport({
+      severity: 'comical',
+      enabled: false,
+      host: 'some-host',
+      projectId: 'some-project-id',
+      projectKey: 'some-project-key',
+      environment: 'unit-test',
+      version: '0.0.0'
+    })
+    stubs.close.resolves()
+
+    stream.end()
+    await once(stream, 'close')
+
+    expect(stubs.close.callCount).to.equal(1)
+  })
+  test('it handles errors from errbit close', async () => {
+    const stream = errbitTransport({
+      severity: 'comical',
+      enabled: false,
+      host: 'some-host',
+      projectId: 'some-project-id',
+      projectKey: 'some-project-key',
+      environment: 'unit-test',
+      version: '0.0.0'
+    })
+    stubs.close.rejects(new Error('bang!'))
+
+    let err
+    stream.on('error', (error) => {
+      err = error
+    })
+    stream.end()
+    await once(stream, 'close')
+
+    expect(err).to.equal(undefined)
+    expect(stubs.consoleError.lastCall.args[0]).to.equal(new Error('bang!'))
+  })
+})

--- a/test/lib/logging/errbit.js
+++ b/test/lib/logging/errbit.js
@@ -1,0 +1,217 @@
+'use strict'
+const Lab = require('@hapi/lab')
+const { expect } = require('@hapi/code')
+const { experiment, test, beforeEach, afterEach } = exports.lab = Lab.script()
+const { stub } = require('sinon')
+const proxyquire = require('proxyquire')
+
+const stubs = {
+  Notifier: stub(),
+  notify: stub(),
+  flush: stub()
+}
+
+const Errbit = proxyquire('../../../server/lib/logging/errbit', {
+  '@airbrake/node': { Notifier: stubs.Notifier }
+})
+
+experiment('Errbit', () => {
+  beforeEach(() => {
+    stubs.Notifier.callsFake(() => ({
+      notify: stubs.notify,
+      addFilter: stubs.addFilter,
+      flush: stubs.flush
+    }))
+    stubs.flush.callsFake(() => Promise.resolve())
+    stubs.notify.callsFake(() => Promise.resolve())
+  })
+  afterEach(() => {
+    for (const stub of Object.values(stubs)) {
+      stub.reset()
+    }
+  })
+
+  test('when enable is false no attempt is made to send notices to airbrake', async () => {
+    const options = {
+      severity: 'comical',
+      enabled: false,
+      host: 'some-host',
+      projectId: 'some-project-id',
+      projectKey: 'some-project-key',
+      environment: 'unit-test',
+      version: '0.0.0'
+    }
+    const errbit = new Errbit(options)
+
+    await errbit.send({
+      err: {
+        name: 'some-name',
+        message: 'some-message',
+        stack: 'some-stack',
+        code: 1234
+      }
+    })
+
+    expect(stubs.notify.called).to.equal(false)
+  })
+
+  test('when enable is true notices are sent to airbrake', async () => {
+    const options = {
+      severity: 'comical',
+      enabled: true,
+      host: 'some-host',
+      projectId: 'some-project-id',
+      projectKey: 'some-project-key',
+      environment: 'unit-test',
+      version: '0.0.0'
+    }
+    const errbit = new Errbit(options)
+
+    await errbit.send({
+      err: {
+        name: 'some-name',
+        message: 'some-message',
+        stack: 'some-stack',
+        code: 1234
+      }
+    })
+
+    expect(stubs.notify.called).to.equal(true)
+  })
+
+  test('when enable is false, and close is called, airbrake remains unflushed', async () => {
+    const options = {
+      severity: 'comical',
+      enabled: false,
+      host: 'some-host',
+      projectId: 'some-project-id',
+      projectKey: 'some-project-key',
+      environment: 'unit-test',
+      version: '0.0.0'
+    }
+    const errbit = new Errbit(options)
+
+    await errbit.close()
+
+    expect(stubs.flush.called).to.equal(false)
+  })
+
+  test('when enable is true, and close is called, airbrake is flushed', async () => {
+    const options = {
+      severity: 'comical',
+      enabled: true,
+      host: 'some-host',
+      projectId: 'some-project-id',
+      projectKey: 'some-project-key',
+      environment: 'unit-test',
+      version: '0.0.0'
+    }
+    const errbit = new Errbit(options)
+
+    await errbit.close()
+
+    expect(stubs.flush.called).to.equal(true)
+  })
+
+  test('when incoming data contains an err key, the err is properly formatted before sending', async () => {
+    const options = {
+      severity: 'comical',
+      enabled: true,
+      host: 'some-host',
+      projectId: 'some-project-id',
+      projectKey: 'some-project-key',
+      environment: 'unit-test',
+      version: '0.0.0'
+    }
+    const errbit = new Errbit(options)
+
+    await errbit.send({
+      err: {
+        name: 'some-name',
+        message: 'some-message',
+        stack: 'some-stack',
+        code: 1234
+      }
+    })
+
+    expect(stubs.notify.lastCall.args[0].error).to.equal({
+      name: 'some-name',
+      message: 'some-message',
+      stack: 'some-stack',
+      code: 1234
+    })
+  })
+
+  test('when incoming data contains req/res information, it is added to the sent notice', async () => {
+    const options = {
+      severity: 'comical',
+      enabled: true,
+      host: 'some-host',
+      projectId: 'some-project-id',
+      projectKey: 'some-project-key',
+      environment: 'unit-test',
+      version: '0.0.0'
+    }
+    const errbit = new Errbit(options)
+
+    await errbit.send({
+      err: {
+        name: 'some-name',
+        message: 'some-message',
+        stack: 'some-stack',
+        code: 1234
+      },
+      req: {
+        url: '/some/path',
+        method: 'GET',
+        query: {
+          a: 1
+        }
+      },
+      res: {
+        statusCode: 418
+      }
+    })
+
+    expect(stubs.notify.lastCall.args[0].context.httpMethod).to.equal('GET')
+    expect(stubs.notify.lastCall.args[0].context.route).to.equal('/some/path')
+    expect(stubs.notify.lastCall.args[0].params).to.equal({
+      request: {
+        url: '/some/path',
+        method: 'GET',
+        query: {
+          a: 1
+        }
+      },
+      response: {
+        statusCode: 418
+      }
+    })
+  })
+
+  test('the environment, version and severity are added to notices before sending', async () => {
+    const options = {
+      severity: 'comical',
+      enabled: true,
+      host: 'some-host',
+      projectId: 'some-project-id',
+      projectKey: 'some-project-key',
+      environment: 'unit-test',
+      version: '0.0.0'
+    }
+    const errbit = new Errbit(options)
+
+    await errbit.send({
+      err: {
+        name: 'some-name',
+        message: 'some-message',
+        stack: 'some-stack',
+        code: 1234
+      }
+    })
+
+    expect(stubs.notify.lastCall.args[0].context.version).to.equal('0.0.0')
+    expect(stubs.notify.lastCall.args[0].context.environment).to.equal('unit-test')
+    expect(stubs.notify.lastCall.args[0].context.severity).to.equal('comical')
+  })
+})

--- a/test/util.js
+++ b/test/util.js
@@ -56,7 +56,7 @@ lab.experiment('util / outbound request helpers : request', () => {
     expect(postResult).to.equal(mockResponse.payload)
   })
 
-  lab.test('request adds the method and url (with any key redacted) to wreck request errors', async () => {
+  lab.test('request adds the method and url (with query strings removed) to wreck request errors', async () => {
     const method = 'get'
     const url = '/some/get/url?a=1&b=2&key=secret&c=4'
     const requestOptions = {
@@ -74,7 +74,7 @@ lab.experiment('util / outbound request helpers : request', () => {
       err = e
     }
 
-    expect(err.message).to.equal('Response Error: some response error on GET /some/get/url?a=1&b=2&key=<redacted>&c=4')
+    expect(err.message).to.equal('Response Error: some response error on GET /some/get/url')
   })
 
   lab.test('request does not add the method and url to wreck non-request errors', async () => {


### PR DESCRIPTION
# FSR-1052 | Errbit

This PR will enable the sending of errors to Errbit, our error aggregator.
It does this by adding an extra 'transport' to pino, our new logging tool.

## Details
- Adds a new custom transport to pino, which takes log messages containing the `err` key, reformats them and forwards them to Errbit.